### PR TITLE
Start CI with Black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| /analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude \pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output
+          options: --diff --color --exclude /(\pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output)/

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude '/(\pidcalib/ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: --diff --color --exclude '/(pidcalib | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,5 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          #options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
-          options: --verbose --diff --color --exclude '/pidcalib/'
+          options: --verbose --diff --color --exclude '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --extend-exclude /(\pidcalib| \datafiles| \analysis/\examples| \analysis/\Scripts/\Archive| \analysis/\Scripts/\.snakemake| \analysis/\Scripts/\Dict_output)/
+          options: --verbose --diff --color --extend-exclude /(\pidcalib|\datafiles|\analysis/\examples|\analysis/\Scripts/\Archive|\analysis/\Scripts/\.snakemake|\analysis/\Scripts/\Dict_output)/

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   lint:
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --exclude '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/'
+          options: "--verbose --diff --color --exclude-extend '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/' "

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color 
+          options: --diff --color --exclude \pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: "--verbose --diff --color --exclude-extend '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/' "
+          options: "--verbose --diff --color --extend-exclude '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/' "

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --extend-exclude /(\pidcalib |\datafiles |\analysis/\examples |\analysis/\Scripts/\Archive |\analysis/\Scripts/\.snakemake |\analysis/\Scripts/\Dict_output)/
+          options: --verbose --diff --color --extend-exclude /(\pidcalib| \datafiles| \analysis/\examples| \analysis/\Scripts/\Archive| \analysis/\Scripts/\.snakemake| \analysis/\Scripts/\Dict_output)/

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| /analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude '/(pidcalib | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: -verbos --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        with: 
+          options: --diff --color 

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude '/(\pidcalib\ | \datafiles\ | \analysis\examples\| \analysis\Scripts\Archive\ | \analysis\Scripts\.snakemake\ | \analysis\Scripts\Dict_output\)/'
+          options: --diff --color --exclude '/(\pidcalib/ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude /(\pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output)/
+          options: --diff --color --exclude '/(\pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --extend-exclude /(/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/)/
+          options: --verbose --diff --color --extend-exclude /(\pidcalib|\datafiles|\analysis\examples|\analysis\Scripts\Archive|\analysis\Scripts\.snakemake|\analysis\Scripts\Dict_output)/

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          #options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| analysis/Scripts/Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: --verbose --diff --color --exclude '/pidcalib/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --diff --color --exclude '/(\pidcalib | \datafiles | \analysis\examples| \analysis\Scripts\Archive | \analysis\Scripts\.snakemake | \analysis\Scripts\Dict_output)/'
+          options: --diff --color --exclude '/(\pidcalib\ | \datafiles\ | \analysis\examples\| \analysis\Scripts\Archive\ | \analysis\Scripts\.snakemake\ | \analysis\Scripts\Dict_output\)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: --verbose --diff --color --extend-exclude /(\pidcalib|\datafiles|\analysis\examples|\analysis\Scripts\Archive|\analysis\Scripts\.snakemake|\analysis\Scripts\Dict_output)/
+          options: --verbose --diff --color --extend-exclude /(\pidcalib |\datafiles |\analysis/\examples |\analysis/\Scripts/\Archive |\analysis/\Scripts/\.snakemake |\analysis/\Scripts/\Dict_output)/

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: -verbos --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'
+          options: --verbose --diff --color --exclude '/(/\pidcalib/\ | \datafiles/ | \analysis\examples/| \analysis\Scripts\Archive/ | \analysis\Scripts\.snakemake/ | \analysis\Scripts\Dict_output/)/'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with: 
-          options: "--verbose --diff --color --extend-exclude '/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/' "
+          options: --verbose --diff --color --extend-exclude /(/pidcalib/ | /datafiles/ | /analysis/examples/ | /analysis/Scripts/Archive/ | /analysis/Scripts/.snakemake/ | /analysis/Scripts/Dict_output/)/

--- a/analysis/Scripts/Archive/Selection_eff.py
+++ b/analysis/Scripts/Archive/Selection_eff.py
@@ -32,16 +32,16 @@ for job in dictionary:
 		#turbo = "lcplus_Hlt2CharmHadXicpToPpKmPipTurboDecision_TOS==1"
         turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS == 1"
         directory = "/data/bfys/jdevries/gangadir/workspace/jdevries/LocalXML/"
-		Lc_MC_filename = "output/MC_Lc2pKpiTuple_" + ID + ".root"
+        Lc_MC_filename = "output/MC_Lc2pKpiTuple_" + ID + ".root"
 	
     else:
         particle = "Lc"
         #ID = "25203000"
-		ID = "25103006"
+        ID = "25103006"
 		#turbo = "lcplus_Hlt2CharmHadLcpToPpKmPipTurboDecision_TOS==1"
-		turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
-		directory = "/dcache/bfys/jdevries/ntuples/LcAnalysis/ganga/"
-		Lc_MC_filename = "MC_Lc2pKpiTuple_" + ID + ".root"
+        turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
+        directory = "/dcache/bfys/jdevries/ntuples/LcAnalysis/ganga/"
+        Lc_MC_filename = "MC_Lc2pKpiTuple_" + ID + ".root"
 	
     #cuts+= " && " + turbo    
     Lc_MC_filedir = directory + str(job)

--- a/analysis/Scripts/Archive/Selection_eff.py
+++ b/analysis/Scripts/Archive/Selection_eff.py
@@ -28,7 +28,7 @@ for job in dictionary:
     if (job == 30):
         particle = "Xic"
         #ID = "26103090"
-		ID = "25103029"
+        ID = "25103029"
 		#turbo = "lcplus_Hlt2CharmHadXicpToPpKmPipTurboDecision_TOS==1"
         turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS == 1"
         directory = "/data/bfys/jdevries/gangadir/workspace/jdevries/LocalXML/"

--- a/analysis/Scripts/Archive/v2_Trigger_eff.py
+++ b/analysis/Scripts/Archive/v2_Trigger_eff.py
@@ -29,16 +29,16 @@ for job in dictionary:
         ID = "25103029"
 		#turbo = "lcplus_Hlt2CharmHadXicpToPpKmPipTurboDecision_TOS==1"
         turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
-		Lc_MC_filename = "output/MC_Lc2pKpiTuple_" + ID + ".root"
-		directory = "/data/bfys/jdevries/gangadir/workspace/jdevries/LocalXML/"
+        Lc_MC_filename = "output/MC_Lc2pKpiTuple_" + ID + ".root"
+        directory = "/data/bfys/jdevries/gangadir/workspace/jdevries/LocalXML/"
 	
     else:
         particle = "Lc"
         ID = "25103006"
 		#turbo = "lcplus_Hlt2CharmHadLcpToPpKmPipTurboDecision_TOS==1"
-		turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
-		Lc_MC_filename = "MC_Lc2pKpiTuple_" + ID + ".root"
-		directory = "/dcache/bfys/jdevries/ntuples/LcAnalysis/ganga/"
+        turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
+        Lc_MC_filename = "MC_Lc2pKpiTuple_" + ID + ".root"
+        directory = "/dcache/bfys/jdevries/ntuples/LcAnalysis/ganga/"
 	
     #cuts+= " && " + turbo    
     Lc_MC_filedir = directory + str(job)

--- a/analysis/Scripts/Archive/v2_Trigger_eff.py
+++ b/analysis/Scripts/Archive/v2_Trigger_eff.py
@@ -28,7 +28,7 @@ for job in dictionary:
         particle = "Xic"
         ID = "25103029"
 		#turbo = "lcplus_Hlt2CharmHadXicpToPpKmPipTurboDecision_TOS==1"
-		turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
+        turbo = "lcplus_Hlt2CharmHadD2HHHDecision_TOS==1"
 		Lc_MC_filename = "output/MC_Lc2pKpiTuple_" + ID + ".root"
 		directory = "/data/bfys/jdevries/gangadir/workspace/jdevries/LocalXML/"
 	

--- a/analysis/Scripts/MC_job_Entries.py
+++ b/analysis/Scripts/MC_job_Entries.py
@@ -20,17 +20,17 @@ for job in parsJob:
         if (int(job) >= 95 and int(job) <= 108):
             run = 2
 			
-			XicMCCuts = "{0} && {1}".format(getMCCuts("Xic",run), "lcplus_MM > 2375")
-			XicDataCuts = getDataCuts(run)
+            XicMCCuts = "{0} && {1}".format(getMCCuts("Xic",run), "lcplus_MM > 2375")
+            XicDataCuts = getDataCuts(run)
 
-			LcMCCuts = "{0} && {1}".format(getMCCuts("Lc",run), "lcplus_MM < 2375")
-			LcDataCuts = getDataCuts(run)
+            LcMCCuts = "{0} && {1}".format(getMCCuts("Lc",run), "lcplus_MM < 2375")
+            LcDataCuts = getDataCuts(run)
 
         else:
-			run = 1
+            run = 1
 		
-			XicDataCuts = "{0} && {1}".format(getDataCuts(run), "lcplus_MM > 2375")
-			LcDataCuts = "{0} && {1}".format(getDataCuts(run), "lcplus_MM < 2375")
+            XicDataCuts = "{0} && {1}".format(getDataCuts(run), "lcplus_MM > 2375")
+            LcDataCuts = "{0} && {1}".format(getDataCuts(run), "lcplus_MM < 2375")
 
         tree = TChain("tuple_Lc2pKpi/DecayTree")
         PATH = "/dcache/bfys/jdevries/ntuples/LcAnalysis/ganga/" + job
@@ -41,39 +41,39 @@ for job in parsJob:
                                 tree.Add(os.path.join(subdir,file))
 
         if(run == 2):
-			XicTree = tree.CopyTree(XicMCCuts)
-			XicTree = XicTree.CopyTree(XicDataCuts)
+            XicTree = tree.CopyTree(XicMCCuts)
+            XicTree = XicTree.CopyTree(XicDataCuts)
 
-			LcTree = tree.CopyTree(LcMCCuts)
-			LcTree = LcTree.CopyTree(LcDataCuts)
+            LcTree = tree.CopyTree(LcMCCuts)
+            LcTree = LcTree.CopyTree(LcDataCuts)
 
-			print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")		
+            print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")		
         if(GRAPHS == True):
-			XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
-			LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
+            XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
+            LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
 
-			LcTree.Draw("lcplus_MM>>LcMasshist")
-			c1.SaveAs(job + "_Lc_MC.pdf")
-			XicTree.Draw("lcplus_MM>>XicMasshist")
-			c1.SaveAs(job + "_Xic_MC.pdf")
+            LcTree.Draw("lcplus_MM>>LcMasshist")
+            c1.SaveAs(job + "_Lc_MC.pdf")
+            XicTree.Draw("lcplus_MM>>XicMasshist")
+            c1.SaveAs(job + "_Xic_MC.pdf")
 
         del XicMasshist
         del LcMasshist
        
 	elif(run == 1):
-		XicTree = tree.CopyTree(XicDataCuts)
-		LcTree = tree.CopyTree(LcDataCuts)
+        XicTree = tree.CopyTree(XicDataCuts)
+        LcTree = tree.CopyTree(LcDataCuts)
 		
-		print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
+        print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
 
-		if(GRAPHS == True):
-			XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
-			LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
+        if(GRAPHS == True):
+            XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
+            LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
 
-			LcTree.Draw("lcplus_MM>>LcMasshist")
-			c1.SaveAs(job + "_Lc_MC.pdf")
-			XicTree.Draw("lcplus_MM>>XicMasshist")
-			c1.SaveAs(job + "_Xic_MC.pdf")
+            LcTree.Draw("lcplus_MM>>LcMasshist")
+            c1.SaveAs(job + "_Lc_MC.pdf")
+            XicTree.Draw("lcplus_MM>>XicMasshist")
+            c1.SaveAs(job + "_Xic_MC.pdf")
 
-		del XicMasshist
-		del LcMasshist
+        del XicMasshist
+        del LcMasshist

--- a/analysis/Scripts/MC_job_Entries.py
+++ b/analysis/Scripts/MC_job_Entries.py
@@ -18,7 +18,7 @@ parsJob = jobs.split(',')
 for job in parsJob:
 
         if (int(job) >= 95 and int(job) <= 108):
-			run = 2
+            run = 2
 			
 			XicMCCuts = "{0} && {1}".format(getMCCuts("Xic",run), "lcplus_MM > 2375")
 			XicDataCuts = getDataCuts(run)
@@ -47,9 +47,8 @@ for job in parsJob:
 			LcTree = tree.CopyTree(LcMCCuts)
 			LcTree = LcTree.CopyTree(LcDataCuts)
 
-			print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
-		
-		if(GRAPHS == True):
+			print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")		
+        if(GRAPHS == True):
 			XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
 			LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
 
@@ -58,8 +57,8 @@ for job in parsJob:
 			XicTree.Draw("lcplus_MM>>XicMasshist")
 			c1.SaveAs(job + "_Xic_MC.pdf")
 
-		del XicMasshist
-		del LcMasshist
+        del XicMasshist
+        del LcMasshist
        
 	elif(run == 1):
 		XicTree = tree.CopyTree(XicDataCuts)

--- a/analysis/Scripts/MC_job_Entries.py
+++ b/analysis/Scripts/MC_job_Entries.py
@@ -48,9 +48,9 @@ for job in parsJob:
             LcTree = LcTree.CopyTree(LcDataCuts)
 
             print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")		
-        if(GRAPHS == True):
-            XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
-            LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
+            if(GRAPHS == True):
+                XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
+                LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
 
             LcTree.Draw("lcplus_MM>>LcMasshist")
             c1.SaveAs(job + "_Lc_MC.pdf")
@@ -59,16 +59,15 @@ for job in parsJob:
 
         del XicMasshist
         del LcMasshist
-       
-        elif(run == 1):
+
+        if(run == 1):
             XicTree = tree.CopyTree(XicDataCuts)
             LcTree = tree.CopyTree(LcDataCuts)
-		
-        print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
+            print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
 
-        if(GRAPHS == True):
-            XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
-            LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
+            if(GRAPHS == True):
+                XicMasshist = ROOT.TH1F("XicMasshist","Histogram of Xic mass, job: "+ job ,nbin,XicMassRange[0],XicMassRange[1])
+                LcMasshist = ROOT.TH1F("LcMasshist","Histogram of Lc mass, job: "+ job ,nbin,LcMassRange[0],LcMassRange[1])
 
             LcTree.Draw("lcplus_MM>>LcMasshist")
             c1.SaveAs(job + "_Lc_MC.pdf")

--- a/analysis/Scripts/MC_job_Entries.py
+++ b/analysis/Scripts/MC_job_Entries.py
@@ -19,7 +19,7 @@ for job in parsJob:
 
         if (int(job) >= 95 and int(job) <= 108):
             run = 2
-			
+
             XicMCCuts = "{0} && {1}".format(getMCCuts("Xic",run), "lcplus_MM > 2375")
             XicDataCuts = getDataCuts(run)
 
@@ -60,7 +60,7 @@ for job in parsJob:
         del XicMasshist
         del LcMasshist
        
-	elif(run == 1):
+    elif(run == 1):
         XicTree = tree.CopyTree(XicDataCuts)
         LcTree = tree.CopyTree(LcDataCuts)
 		

--- a/analysis/Scripts/MC_job_Entries.py
+++ b/analysis/Scripts/MC_job_Entries.py
@@ -60,9 +60,9 @@ for job in parsJob:
         del XicMasshist
         del LcMasshist
        
-    elif(run == 1):
-        XicTree = tree.CopyTree(XicDataCuts)
-        LcTree = tree.CopyTree(LcDataCuts)
+        elif(run == 1):
+            XicTree = tree.CopyTree(XicDataCuts)
+            LcTree = tree.CopyTree(LcDataCuts)
 		
         print("The nb of entries for job " + job + " is (Xic: " + str(XicTree.GetEntries()) + ";Lc: " + str(LcTree.GetEntries())+ ")")
 


### PR DESCRIPTION
This would run the Black Linter on each push and MR, the output of this would be placed into the console. 

At the moment the --diff flag just reports the things Black would reformat - but it doesn't actually do them.

I guess in the first commit it's generally going to be very unhappy. Maybe we should run Black over the whole codebase first and then setup the CI